### PR TITLE
Tyler responsive stats

### DIFF
--- a/echo
+++ b/echo
@@ -1,0 +1,4 @@
+  master
+* tyler_responsive_stats
+  master
+* tyler_responsive_stats

--- a/src/components/SimpleTable.tsx
+++ b/src/components/SimpleTable.tsx
@@ -103,7 +103,7 @@ const SimpleTable = (props: IDataTableProps) => {
 
   return (
     <Paper className={classes.paper}>
-      <TableContainer style={{ height: props.height, overflow: 'hidden' }}>
+      <TableContainer style={{ overflow: 'hidden' }}>
         <Table
           className={classes.table}
           aria-labelledby="tableTitle"

--- a/src/components/VerticalNav.tsx
+++ b/src/components/VerticalNav.tsx
@@ -42,14 +42,17 @@ const useStyles = makeStyles((theme: Theme) =>
       zIndex: theme.zIndex.drawer + 1,
     },
     drawer: {
-      [theme.breakpoints.up('sm')]: {
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+      [theme.breakpoints.up('md')]: {
         width: drawerWidth,
         flexShrink: 0,
       },
     },
     menuButton: {
       marginRight: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
+      [theme.breakpoints.up('md')]: {
         display: 'none',
       },
     },
@@ -71,6 +74,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     content: {
       flexGrow: 1,
+      minWidth: '200px',
       padding: theme.spacing(3),
     },
   })
@@ -206,7 +210,7 @@ export default function ClippedDrawer({ children }) {
       </AppBar>
       <nav className={classes.drawer} aria-label="mailbox folders">
         {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
-        <Hidden smUp implementation="css">
+        <Hidden mdUp implementation="css">
           <Drawer
             variant="temporary"
             anchor={theme.direction === 'rtl' ? 'right' : 'left'}

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -233,7 +233,7 @@ function UserStats() {
                   </Grid>
                 </Grid>
               </Box>
-              <div style={{ height: '300px', paddingRight: '20px' }}>
+              <div style={{ height: '350px', paddingRight: '20px' }}>
                 {series && (
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={series}>

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -79,20 +79,10 @@ const useStyles = makeStyles(theme => ({
   paper: {
     //   backgroundColor: '20232a',
     //   color: 'white',
-    height: '500px',
-    [theme.breakpoints.down('sm')]: {
-      height: '600px',
-    },
-  },
-  text: {
-    // color: 'white',
   },
   divider: {
     background: '#BEBEBE',
     height: '1px',
-  },
-  icon: {
-    /* fill: 'white', */
   },
   select: {
     '&:before': {
@@ -102,13 +92,13 @@ const useStyles = makeStyles(theme => ({
       borderColor: 'white !important',
     },
   },
-  chartCard: {
+  chartHeaderCard: {
     height: '100px',
     padding: '20px',
     lineHeight: '25px',
   },
   infoCard: {
-    height: '213px',
+    height: '100%',
     padding: '16px',
   },
 }))
@@ -176,7 +166,7 @@ function UserStats() {
   }, [userId, timeInterval])
 
   const ChartCard = ({ label, value }) => (
-    <Box className={classes.chartCard}>
+    <Box className={classes.chartHeaderCard}>
       <Typography variant="body1" gutterBottom={true}>
         <span style={{ fontWeight: 700 }}>{label}</span>
       </Typography>
@@ -243,7 +233,7 @@ function UserStats() {
                   </Grid>
                 </Grid>
               </Box>
-              <div style={{ height: '350px', paddingRight: '20px' }}>
+              <div style={{ height: '300px', paddingRight: '20px' }}>
                 {series && (
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={series}>
@@ -281,17 +271,13 @@ function UserStats() {
                 display="flex"
                 align-items="center"
                 marginTop="6px"
+                marginBottom="6px"
                 marginLeft="20px"
               >
                 <Select
                   style={{ height: '35px' }}
                   value={timeInterval}
                   className={classes.select}
-                  inputProps={{
-                    classes: {
-                      icon: classes.icon,
-                    },
-                  }}
                   onChange={(e: any) => {
                     setTimeInterval(e.target.value)
                   }}
@@ -308,7 +294,7 @@ function UserStats() {
       </Grid>
 
       <Grid item xs={12} md={4}>
-        <div style={{ height: '500px' }}>
+        <div>
           {neighbors && (
             <SimpleTable
               columns={[
@@ -369,13 +355,13 @@ function UserStats() {
                     : ` @${userStats?.roleInfo?.next_role?.name}`
                 }
               </Typography>
-              <Typography variant="body1">
+              {/* <Typography variant="body1">
                 Role Rank:
                 {
                   // @ts-ignore
                   ` 5/11`
                 }
-              </Typography>
+              </Typography> */}
 
               <Typography variant="body1">
                 {
@@ -402,7 +388,7 @@ function UserStats() {
       </Grid>
 
       <Grid item xs={12} md={4}>
-        <div style={{ height: '213px' }}>
+        <div>
           {userStats && (
             <SimpleTable
               columns={[

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState, useRef } from 'react'
 import { useHistory } from 'react-router'
 import Typography from '@material-ui/core/Typography'
 import Container from '@material-ui/core/Container'
-import Grid from '@material-ui/core/Grid'
 import Paper from '@material-ui/core/Paper'
 import Divider from '@material-ui/core/Divider'
+import Grid, { GridSpacing } from '@material-ui/core/Grid'
 import Select from '@material-ui/core/Select'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
@@ -196,7 +196,7 @@ function UserStats() {
 
   return (
     <Grid container spacing={3}>
-      <Grid item xs={8}>
+      <Grid item xs={12} sm={8}>
         <Paper style={{ height: '500px' }}>
           <Grid container>
             <Grid item xs={12}>
@@ -287,7 +287,8 @@ function UserStats() {
           </Grid>
         </Paper>
       </Grid>
-      <Grid item xs={4}>
+
+      <Grid item xs={12} sm={4}>
         <div style={{ height: '500px' }}>
           {neighbors && (
             <SimpleTable
@@ -324,7 +325,7 @@ function UserStats() {
         </div>
       </Grid>
 
-      <Grid item xs={8}>
+      <Grid item xs={12} sm={8}>
         <Paper className={classes.infoCard}>
           {userStats && (
             <div>
@@ -381,7 +382,7 @@ function UserStats() {
         </Paper>
       </Grid>
 
-      <Grid item xs={4}>
+      <Grid item xs={12} sm={4}>
         <div style={{ height: '213px' }}>
           {userStats && (
             <SimpleTable

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -26,6 +26,7 @@ import {
 import { api as axios } from '../../services'
 
 import CustomTooltipContent from '../../components/CustomTooltipContent'
+import { useMediaQuery } from '@material-ui/core'
 
 interface ParamTypes {
   userId: string
@@ -78,6 +79,10 @@ const useStyles = makeStyles(theme => ({
   paper: {
     //   backgroundColor: '20232a',
     //   color: 'white',
+    height: '500px',
+    [theme.breakpoints.down('sm')]: {
+      height: '600px',
+    },
   },
   text: {
     // color: 'white',
@@ -197,75 +202,77 @@ function UserStats() {
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} md={8}>
-        <Paper style={{ height: '510px' }}>
+        <Paper style={{ height: '600px' }}>
           <Grid container>
-            <Box display="flex">
-              <Grid container spacing={3}>
-                <Grid item xs={6} md={3}>
-                  <ChartCard
-                    label="Discord User Name"
-                    value={userStats && userStats?.username}
-                  />
-                </Grid>
-                <Grid item xs={6} md={3}>
-                  <ChartCard
-                    label="Leaderboard Placement"
-                    value={
-                      userStats && `#${userStats.stats[timeInterval].rank}`
-                    }
-                  />
-                </Grid>
-                <Grid item xs={6} md={3}>
-                  <ChartCard
-                    label="Hours Studied"
-                    value={
-                      userStats && userStats.stats[timeInterval].study_time
-                    }
-                  />
-                </Grid>
-                <Grid item xs={6} md={3}>
-                  <ChartCard
-                    label="Average / day"
-                    value={
-                      userStats &&
-                      (
-                        userStats.stats[timeInterval].study_time /
-                        timeIntervalToDays[timeInterval]
-                      ).toFixed(2)
-                    }
-                  />
-                </Grid>
-              </Grid>
-            </Box>
-            <div style={{ height: '350px', paddingRight: '20px' }}>
-              {series && (
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={series}>
-                    <CartesianGrid
-                      stroke="#eee"
-                      strokeDasharray="5 3"
-                      vertical={false}
+            <Grid item xs={12}>
+              <Box display="flex">
+                <Grid container>
+                  <Grid item xs={6} md={3}>
+                    <ChartCard
+                      label="Discord User Name"
+                      value={userStats && userStats?.username}
                     />
-                    <XAxis dataKey="date" />
-                    <YAxis yAxisId="left" orientation="left" />
-                    <Tooltip
-                      content={
-                        // @ts-ignore
-                        <CustomTooltipContent />
+                  </Grid>
+                  <Grid item xs={6} md={3}>
+                    <ChartCard
+                      label="Leaderboard Placement"
+                      value={
+                        userStats && `#${userStats.stats[timeInterval].rank}`
                       }
-                      cursor={{ fill: '#E0E0E0' }}
                     />
-                    <Bar
-                      yAxisId="left"
-                      dataKey="study_time"
-                      fill="#9656A1"
-                      radius={7}
-                      barSize={10}
+                  </Grid>
+                  <Grid item xs={6} md={3}>
+                    <ChartCard
+                      label="Hours Studied"
+                      value={
+                        userStats && userStats.stats[timeInterval].study_time
+                      }
                     />
-                  </BarChart>
-                </ResponsiveContainer>
-              )}
-            </div>
+                  </Grid>
+                  <Grid item xs={6} md={3}>
+                    <ChartCard
+                      label="Average / day"
+                      value={
+                        userStats &&
+                        (
+                          userStats.stats[timeInterval].study_time /
+                          timeIntervalToDays[timeInterval]
+                        ).toFixed(2)
+                      }
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+              <div style={{ height: '350px', paddingRight: '20px' }}>
+                {series && (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={series}>
+                      <CartesianGrid
+                        stroke="#eee"
+                        strokeDasharray="5 3"
+                        vertical={false}
+                      />
+                      <XAxis dataKey="date" />
+                      <YAxis yAxisId="left" orientation="left" />
+                      <Tooltip
+                        content={
+                          // @ts-ignore
+                          <CustomTooltipContent />
+                        }
+                        cursor={{ fill: '#E0E0E0' }}
+                      />
+                      <Bar
+                        yAxisId="left"
+                        dataKey="study_time"
+                        fill="#9656A1"
+                        radius={7}
+                        barSize={10}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
+            </Grid>
             <Grid item xs={12}>
               <Divider className={classes.divider} />
             </Grid>

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -199,61 +199,73 @@ function UserStats() {
       <Grid item xs={12} md={8}>
         <Paper style={{ height: '510px' }}>
           <Grid container>
-            <Grid item xs={12}>
-              <Box display="flex">
-                <ChartCard
-                  label="Discord User Name"
-                  value={userStats && userStats?.username}
-                />
-                <ChartCard
-                  label="Leaderboard Placement"
-                  value={userStats && `#${userStats.stats[timeInterval].rank}`}
-                />
-                <ChartCard
-                  label="Hours Studied"
-                  value={userStats && userStats.stats[timeInterval].study_time}
-                />
-                <ChartCard
-                  label="Average / day"
-                  value={
-                    userStats &&
-                    (
-                      userStats.stats[timeInterval].study_time /
-                      timeIntervalToDays[timeInterval]
-                    ).toFixed(2)
-                  }
-                />
-              </Box>
-              <div style={{ height: '350px', paddingRight: '20px' }}>
-                {series && (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={series}>
-                      <CartesianGrid
-                        stroke="#eee"
-                        strokeDasharray="5 3"
-                        vertical={false}
-                      />
-                      <XAxis dataKey="date" />
-                      <YAxis yAxisId="left" orientation="left" />
-                      <Tooltip
-                        content={
-                          // @ts-ignore
-                          <CustomTooltipContent />
-                        }
-                        cursor={{ fill: '#E0E0E0' }}
-                      />
-                      <Bar
-                        yAxisId="left"
-                        dataKey="study_time"
-                        fill="#9656A1"
-                        radius={7}
-                        barSize={10}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                )}
-              </div>
-            </Grid>
+            <Box display="flex">
+              <Grid container spacing={3}>
+                <Grid item xs={6} md={3}>
+                  <ChartCard
+                    label="Discord User Name"
+                    value={userStats && userStats?.username}
+                  />
+                </Grid>
+                <Grid item xs={6} md={3}>
+                  <ChartCard
+                    label="Leaderboard Placement"
+                    value={
+                      userStats && `#${userStats.stats[timeInterval].rank}`
+                    }
+                  />
+                </Grid>
+                <Grid item xs={6} md={3}>
+                  <ChartCard
+                    label="Hours Studied"
+                    value={
+                      userStats && userStats.stats[timeInterval].study_time
+                    }
+                  />
+                </Grid>
+                <Grid item xs={6} md={3}>
+                  <ChartCard
+                    label="Average / day"
+                    value={
+                      userStats &&
+                      (
+                        userStats.stats[timeInterval].study_time /
+                        timeIntervalToDays[timeInterval]
+                      ).toFixed(2)
+                    }
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+            <div style={{ height: '350px', paddingRight: '20px' }}>
+              {series && (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={series}>
+                    <CartesianGrid
+                      stroke="#eee"
+                      strokeDasharray="5 3"
+                      vertical={false}
+                    />
+                    <XAxis dataKey="date" />
+                    <YAxis yAxisId="left" orientation="left" />
+                    <Tooltip
+                      content={
+                        // @ts-ignore
+                        <CustomTooltipContent />
+                      }
+                      cursor={{ fill: '#E0E0E0' }}
+                    />
+                    <Bar
+                      yAxisId="left"
+                      dataKey="study_time"
+                      fill="#9656A1"
+                      radius={7}
+                      barSize={10}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
             <Grid item xs={12}>
               <Divider className={classes.divider} />
             </Grid>

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -196,8 +196,8 @@ function UserStats() {
 
   return (
     <Grid container spacing={3}>
-      <Grid item xs={12} sm={8}>
-        <Paper style={{ height: '500px' }}>
+      <Grid item xs={12} md={8}>
+        <Paper style={{ height: '510px' }}>
           <Grid container>
             <Grid item xs={12}>
               <Box display="flex">
@@ -288,7 +288,7 @@ function UserStats() {
         </Paper>
       </Grid>
 
-      <Grid item xs={12} sm={4}>
+      <Grid item xs={12} md={4}>
         <div style={{ height: '500px' }}>
           {neighbors && (
             <SimpleTable
@@ -325,7 +325,7 @@ function UserStats() {
         </div>
       </Grid>
 
-      <Grid item xs={12} sm={8}>
+      <Grid item xs={12} md={8}>
         <Paper className={classes.infoCard}>
           {userStats && (
             <div>
@@ -382,7 +382,7 @@ function UserStats() {
         </Paper>
       </Grid>
 
-      <Grid item xs={12} sm={4}>
+      <Grid item xs={12} md={4}>
         <div style={{ height: '213px' }}>
           {userStats && (
             <SimpleTable

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -202,7 +202,7 @@ function UserStats() {
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} md={8}>
-        <Paper style={{ height: '600px' }}>
+        <Paper>
           <Grid container>
             <Grid item xs={12}>
               <Box display="flex">


### PR DESCRIPTION
Changes to the userstats page were made so that the grids for each component take up the full width for smaller screens.

A change to Nav was made so that the min width is 200px (let components shring more).

The drawer now shrinks when for md screens instead of sm screens.

ToDo: Make changes to the graph so as to look better after shrunk to a certain width.

![pic-selected-210505-1630-51](https://user-images.githubusercontent.com/69824969/117205338-7fd5aa00-adbf-11eb-8e90-b019dbf1b504.png)
![pic-selected-210505-1631-00](https://user-images.githubusercontent.com/69824969/117205343-819f6d80-adbf-11eb-8e68-e418a7dee849.png)
![pic-selected-210505-1631-09](https://user-images.githubusercontent.com/69824969/117205344-82380400-adbf-11eb-95f0-a32ebc4c2985.png)
